### PR TITLE
UI design fixes

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -8,17 +8,17 @@
       "sourceRange": {
         "file": "src/vaadin-app-layout.html",
         "start": {
-          "line": 201,
+          "line": 198,
           "column": 6
         },
         "end": {
-          "line": 201,
+          "line": 198,
           "column": 56
         }
       },
       "elements": [
         {
-          "description": "`<vaadin-app-layout>` is a Web Component providing a quick and easy way to get a common application layout structure done.\n\n```\n<vaadin-app-layout>\n <h3 slot=\"branding\">Company Name</h3>\n <vaadin-tabs slot=\"menu\">\n   <vaadin-tab>Menu item</vaadin-tab>\n </vaadin-tabs>\n <div>Page content</div>\n</vaadin-app-layout>\n```\n\n### Styling\n\nThe following Shadow DOM parts of the `<vaadin-app-layout>` are available for styling:\n\nPart name     | Description\n--------------|---------------------------------------------------------|\n`navbar`      | Container for the navigation bar\n`branding`    | Placeholder for the logo or for the app name. By default is invisible on small screens\n`menu`        | Container for an app menu. Placed in the middle of navigation bar.\n`content`     | Container for page content.\n\nThe following custom CSS properties are available for styling:\n\nCustom CSS property | Description | Default value\n---|---|---\n`--vaadin-app-layout-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset\n`--vaadin-app-layout-navbar-height` | Height of the navigation bar and branding inside | `50px`\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)\n\n### Component's slots\n\nThe following slots are available to be set\n\nSlot name     | Description\n--------------|---------------------------------------------------|\nno name       | Default placeholder for the page content\n`branding`    | Placeholder for the logo or application name\n`menu`        | Placeholder for an application menu\n\nSee examples of setting the content into slots in the live demos.",
+          "description": "`<vaadin-app-layout>` is a Web Component providing a quick and easy way to get a common application layout structure done.\n\n```\n<vaadin-app-layout>\n <h3 slot=\"branding\">Company Name</h3>\n <vaadin-tabs slot=\"menu\">\n   <vaadin-tab>Menu item</vaadin-tab>\n </vaadin-tabs>\n <div>Page content</div>\n</vaadin-app-layout>\n```\n\n### Styling\n\nThe following Shadow DOM parts of the `<vaadin-app-layout>` are available for styling:\n\nPart name     | Description\n--------------|---------------------------------------------------------|\n`navbar`      | Container for the navigation bar\n`branding`    | Placeholder for the logo or for the app name. By default is invisible on small screens\n`menu`        | Container for an app menu. Placed in the middle of navigation bar.\n`content`     | Container for page content.\n\nThe following custom CSS properties are available for styling:\n\nCustom CSS property | Description | Default value\n---|---|---\n`--vaadin-app-layout-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset\n`--vaadin-app-layout-navbar-height` | Height of the navigation bar and branding inside | `auto`, depends on the navbar content\n`--vaadin-app-layout-navbar-background` | Background of the navigation bar | slightly gray, depends on the theme\n\nSee [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)\n\n### Component's slots\n\nThe following slots are available to be set\n\nSlot name     | Description\n--------------|---------------------------------------------------|\nno name       | Default placeholder for the page content\n`branding`    | Placeholder for the logo or application name\n`menu`        | Placeholder for an application menu\n\nSee examples of setting the content into slots in the live demos.",
           "summary": "",
           "path": "src/vaadin-app-layout.html",
           "properties": [],
@@ -51,11 +51,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 175,
+                  "line": 172,
                   "column": 8
                 },
                 "end": {
-                  "line": 181,
+                  "line": 178,
                   "column": 9
                 }
               },
@@ -71,11 +71,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 183,
+                  "line": 180,
                   "column": 8
                 },
                 "end": {
-                  "line": 193,
+                  "line": 190,
                   "column": 9
                 }
               },
@@ -196,11 +196,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 159,
+              "line": 156,
               "column": 6
             },
             "end": {
-              "line": 194,
+              "line": 191,
               "column": 7
             }
           },
@@ -219,11 +219,11 @@
               "name": "branding",
               "range": {
                 "start": {
-                  "line": 91,
+                  "line": 87,
                   "column": 8
                 },
                 "end": {
-                  "line": 91,
+                  "line": 87,
                   "column": 37
                 }
               }
@@ -233,11 +233,11 @@
               "name": "menu",
               "range": {
                 "start": {
-                  "line": 94,
+                  "line": 90,
                   "column": 8
                 },
                 "end": {
-                  "line": 94,
+                  "line": 90,
                   "column": 33
                 }
               }
@@ -247,11 +247,11 @@
               "name": "secondary",
               "range": {
                 "start": {
-                  "line": 97,
+                  "line": 93,
                   "column": 8
                 },
                 "end": {
-                  "line": 97,
+                  "line": 93,
                   "column": 38
                 }
               }
@@ -261,11 +261,11 @@
               "name": "",
               "range": {
                 "start": {
-                  "line": 101,
+                  "line": 97,
                   "column": 6
                 },
                 "end": {
-                  "line": 101,
+                  "line": 97,
                   "column": 19
                 }
               }

--- a/demo/element-basic-demos.html
+++ b/demo/element-basic-demos.html
@@ -9,9 +9,14 @@
     <h3>Simple App Layout with brand logo </h3>
     <vaadin-demo-snippet id="element-basic-demos-logo-example" iframe-src="iframe-lumo-styled.html">
       <template preserve-content>
+        <!-- Apply typography and color theme modules globally from `vaadin-lumo-styles` -->
+        <custom-style>
+          <style include="lumo-typography lumo-color">
+          </style>
+        </custom-style>
         <style>
           .content {
-            padding: 5px;
+            padding: 16px;
           }
 
           h3 {
@@ -19,16 +24,25 @@
           }
         </style>
         <vaadin-app-layout>
-          <img slot="branding" referrerpolicy="no-referrer" src="https://i.imgur.com/GPpnszs.png" alt="Vaadin Logo"/>
+          <img slot="branding" referrerpolicy="no-referrer" src="https://i.imgur.com/GPpnszs.png" alt="Vaadin Logo" width="100" height="31" />
 
-          <vaadin-tabs slot="menu" theme="minimal">
-            <vaadin-tab>
+          <vaadin-tabs slot="menu">
+            <vaadin-tab theme="icon-on-top">
               <iron-icon icon="vaadin:home"></iron-icon>
               Page 1
             </vaadin-tab>
-            <vaadin-tab>Page 2</vaadin-tab>
-            <vaadin-tab>Page 3</vaadin-tab>
-            <vaadin-tab>Page 4</vaadin-tab>
+            <vaadin-tab theme="icon-on-top">
+              <iron-icon icon="vaadin:list"></iron-icon>
+              Page 2
+            </vaadin-tab>
+            <vaadin-tab theme="icon-on-top">
+              <iron-icon icon="vaadin:options"></iron-icon>
+              Page 3
+            </vaadin-tab>
+            <vaadin-tab theme="icon-on-top">
+              <iron-icon icon="vaadin:question"></iron-icon>
+              Page 4
+            </vaadin-tab>
           </vaadin-tabs>
 
           <div class="content">
@@ -42,9 +56,14 @@
     <h3>App Layout with text branding and large number of menu items</h3>
     <vaadin-demo-snippet id="element-basic-demos-text-example" iframe-src="iframe-lumo-styled.html">
       <template preserve-content>
+        <!-- Apply typography and color theme modules globally from `vaadin-lumo-styles` -->
+        <custom-style>
+          <style include="lumo-typography lumo-color">
+          </style>
+        </custom-style>
         <style>
           .content {
-            padding: 5px;
+            padding: 16px;
           }
 
           h3 {
@@ -52,9 +71,9 @@
           }
         </style>
         <vaadin-app-layout>
-          <h3 slot="branding">Company Name</h3>
+          <h3 slot="branding" style="margin: 0;">Company</h3>
 
-          <vaadin-tabs slot="menu" theme="minimal">
+          <vaadin-tabs slot="menu">
               <vaadin-tab>Page 1</vaadin-tab>
               <vaadin-tab>Page 2</vaadin-tab>
               <vaadin-tab>Page 3</vaadin-tab>
@@ -76,9 +95,11 @@
     <h3>App Layout on a mobile screen with large number of menu items</h3>
     <vaadin-demo-snippet id="element-basic-demos-mobile-example" iframe-src="iframe-lumo-styled.html" mobile>
       <template preserve-content>
+        <!-- Apply typography and color theme modules globally from `vaadin-lumo-styles` -->
+        <custom-style><style include="lumo-typography lumo-color"></style></custom-style>
         <style>
           .content {
-            padding: 5px;
+            padding: 16px;
           }
 
           h3 {
@@ -86,7 +107,7 @@
           }
         </style>
         <vaadin-app-layout id="app">
-          <vaadin-tabs slot="menu" theme="minimal">
+          <vaadin-tabs slot="menu">
             <vaadin-tab>Page 1</vaadin-tab>
             <vaadin-tab>Page 2</vaadin-tab>
             <vaadin-tab>Page 3</vaadin-tab>
@@ -106,9 +127,11 @@
     <h3>App Layout with material theme</h3>
     <vaadin-demo-snippet id="element-basic-demos-material-example" iframe-src="iframe-material-styled.html">
       <template preserve-content>
+        <!-- Apply typography and color theme modules globally from `vaadin-material-styles` -->
+        <custom-style><style include="material-typography material-color-dark"></style></custom-style>
         <style>
           .content {
-            padding: 5px;
+            padding: 16px;
           }
 
           h3 {

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,7 +16,7 @@
     <template>
       <style>
         :host([mobile]) #demo {
-          width: 375px;
+          max-width: 375px;
         }
       </style>
     </template>

--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -18,22 +18,21 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
       :host {
         display: flex;
         flex-direction: column-reverse;
-        height: 100%;
-        width: 100%;
+        position: fixed;
         top: 0;
         left: 0;
-        position: fixed;
+        right: 0;
         bottom: var(--vaadin-app-layout-viewport-bottom);
         /* CSS API for host */
         --vaadin-app-layout-viewport-bottom: 0;
-        --vaadin-app-layout-navbar-height: 50px;
       }
 
       :host([hidden]) {
         display: none !important;
       }
 
-      [part="branding"] {
+      [part="branding"],
+      [part="secondary"] {
         display: none;
       }
 
@@ -41,17 +40,33 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         flex: none;
         display: flex;
         align-items: center;
-        justify-content: center;
+        height: var(--vaadin-app-layout-navbar-height, auto);
+        background: var(--vaadin-app-layout-navbar-background, #eee);
       }
 
       [part="branding"],
-      [part="navbar"] {
-        height: var(--vaadin-app-layout-navbar-height);
+      [part="secondary"] {
+        /*
+          Makes the menu part horizontally centered on wide viewports,
+          regardless of the size of contents inside the branding
+          and the secondary parts. Prevents unnecessary menu shrinking.
+
+          NOTE: IE requires a unit for the flex-basis value.
+
+          NOTE: `0px` might confuse linters and minifiers.
+        */
+        flex: 1 0 0.001px;
       }
 
       [part="menu"] {
-        width: auto;
+        flex: auto;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         overflow: hidden;
+      }
+
+      [part="menu"] ::slotted(*) {
         max-width: 100%;
       }
 
@@ -67,22 +82,12 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
         }
 
         [part="menu"] {
-          max-width: 60%;
+          flex: initial;
         }
 
-        [part="branding"] {
+        [part="branding"],
+        [part="secondary"] {
           display: flex;
-          position: absolute;
-          top: 0;
-          left: 0;
-          max-width: 20%;
-          max-height: 100%;
-          align-items: center;
-        }
-
-        [part="branding"] ::slotted(*) {
-          max-width: 100%;
-          max-height: 100%;
         }
       }
     </style>
@@ -136,7 +141,8 @@ See <a href="https://vaadin.com/license/cval-3">the website</a> for the complete
        * Custom CSS property | Description | Default value
        * ---|---|---
        * `--vaadin-app-layout-viewport-bottom` | Bottom offset of the visible viewport area | `0` or detected offset
-       * `--vaadin-app-layout-navbar-height` | Height of the navigation bar and branding inside | `50px`
+       * `--vaadin-app-layout-navbar-height` | Height of the navigation bar and branding inside | `auto`, depends on the navbar content
+       * `--vaadin-app-layout-navbar-background` | Background of the navigation bar | slightly gray, depends on the theme
        *
        * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
        *

--- a/theme/lumo/vaadin-app-layout-styles.html
+++ b/theme/lumo/vaadin-app-layout-styles.html
@@ -7,23 +7,26 @@
     <style>
       :host {
         background-color: var(--lumo-base-color);
-        font-family: var(--lumo-font-family);
-        color: var(--lumo-secondary-text-color);
       }
 
       [part="navbar"] {
-        background-color: var(--lumo-base-color);
-        box-shadow: 0 0 0 1px var(--lumo-contrast-20pct);
-        padding: 0 var(--lumo-space-xs);
+        background: var(--vaadin-app-layout-navbar-background, linear-gradient(var(--lumo-shade-5pct), var(--lumo-shade-5pct)) var(--lumo-base-color));
+      }
+
+      [part="menu"] ::slotted(vaadin-tabs) {
+        box-shadow: none;
+        --lumo-font-size-m: var(--lumo-font-size-s);
+        --lumo-icon-size-m: 1.5rem;
       }
 
       @media (min-width: 700px) {
-        [part="branding"] {
-          padding-left: var(--lumo-space-m);
-        }
-
         [part="navbar"] {
           padding: 0 var(--lumo-space-m);
+        }
+
+        [part="menu"] ::slotted(vaadin-tabs) {
+          --lumo-font-size-m: unset;
+          --lumo-icon-size-m: unset;
         }
       }
     </style>

--- a/theme/material/vaadin-app-layout-styles.html
+++ b/theme/material/vaadin-app-layout-styles.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../../vaadin-material-styles/color.html">
+<link rel="import" href="../../../vaadin-material-styles/shadow.html">
 <link rel="import" href="../../../vaadin-material-styles/typography.html">
 
 
@@ -6,20 +7,18 @@
   <template>
     <style>
       :host {
-        background-color: var(--material-base-color);
-        font-family: var(--material-font-family);
-        font-size: var(--material-button-font-size);
-        color: var(--material-secondary-text-color);
+        background-color: var(--material-background-color);
       }
 
       [part="navbar"] {
-        background-color: var(--material-base-color);
-        padding: 0 1em;
+        background: var(--vaadin-app-layout-navbar-background, var(--material-secondary-background-color));
+        box-shadow: var(--material-shadow-elevation-8dp);
       }
 
       @media (min-width: 700px) {
-        [part="branding"] {
-          padding-left: 1em;
+        [part="navbar"] {
+          padding: 0 1em;
+          box-shadow: var(--material-shadow-elevation-4dp);
         }
       }
     </style>


### PR DESCRIPTION
See also: vaadin/vaadin-tabs#115

Changes in core styles:
- Change CSS navbar layout from brute-force absolute to flex
- Change default navbar height to `auto`
- Remove unnecessary branding constrains, fixes #30
- Expose navbar background custom CSS property, use default value
- Support inheriting custom CSS properties, fixes #28

Lumo theme:
- Remove host font and color reset
- Apply background color on navbar to match the original mockups
- Refine spacing for navbar and its contents
- Decrease font size for tabs in the menu part on mobile

Material theme:
- Remove host font and color reset
- Apply background color on navbar
- Add drop shadow for navbar from the Material Design Guide
- Refine spacing for navbar and its contents

Demos:
- Use icon-on-top tabs in the first example
- Remove `theme="minimal"` to restore the proper selected tab indication
- Use explicit branding image size
- Use explicit global content styles
- Increase content padding to match the navbar default
- Use `max-width` for mobile demo, fixes overflow with narrow viewport size

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/35)
<!-- Reviewable:end -->
