### PR TITLE
Use explicit height for the content part in order to allow user content to use relative height as well

### DIFF
--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -69,6 +69,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       [part="content"] {
         flex: auto;
+        height: 100%;
         overflow: auto;
         -webkit-overflow-scrolling: touch;
       }


### PR DESCRIPTION
Fixes #51

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/56)
<!-- Reviewable:end -->
