### PR TITLE
Force display flex

### DIFF
--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -13,7 +13,7 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <style>
       :host {
-        display: flex;
+        display: flex !important;
         flex-direction: column-reverse;
         position: fixed;
         top: 0;


### PR DESCRIPTION
App Layout makes assumes that the host element is always display: flex.

If a user uses <vaadin-app-layout> as the root element of a design in Vaadin Designer, the tool will override the host with display: block, causing unexpected results.

Fixes #57

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/59)
<!-- Reviewable:end -->
