### PR TITLE
Mark overlay property as readOnly

### DIFF
--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -216,11 +216,11 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              *  Drawer is an overlay on top of the content
-             *  Controlled via CSS using --vaadin-app-layout-drawer-overlay: true|false;
-             * @private
+             *  Controlled via CSS using `--vaadin-app-layout-drawer-overlay: true|false`;
              */
             overlay: {
               type: Boolean,
+              readOnly: true,
               value: false,
               reflectToAttribute: true
             }
@@ -234,6 +234,9 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__drawerToggleClickListener = this._drawerToggleClick.bind(this);
         }
 
+        /**
+        * @private
+        */
         connectedCallback() {
           super.connectedCallback();
 
@@ -265,6 +268,9 @@ This program is available under Apache License Version 2.0, available at https:/
           this._updateOverlayMode();
         }
 
+        /**
+        * @private
+        */
         disconnectedCallback() {
           super.disconnectedCallback();
 
@@ -340,7 +346,7 @@ This program is available under Apache License Version 2.0, available at https:/
         _updateOverlayMode() {
           const overlay = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') == 'true';
 
-          this.overlay = overlay;
+          this._setOverlay(overlay);
 
           if (this.overlay) {
             this.drawerOpened = false;


### PR DESCRIPTION
- Remove @private from overlay js doc
- Mark overlay as readOnly
- Add @private to lifecycle methods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/82)
<!-- Reviewable:end -->
