### PR TITLE
Add close-overlay-drawer event support

### DIFF
--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -222,6 +222,16 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * See examples of setting the content into slots in the live demos.
        *
+       * ### Navigation
+       *
+       * As the drawer opens as an overlay in small devices, it makes sense to close it once a navigation happens.
+       *
+       * In order to do so, there are two options:
+       * - If the `vaadin-app-layout` instance is available, then `drawerOpened` can be set to `false`
+       * - If not, a custom event `close-overlay-drawer` can be dispatched either by calling
+       *  `window.dispatchEvent(new CustomEvent('close-overlay-drawer'))` or by calling
+       *  `Vaadin.AppLayoutElement.dispatchCloseOverlayDrawerEvent()`
+       *
        * @memberof Vaadin
        * @mixes Vaadin.ElementMixin
        * @mixes Vaadin.ThemableMixin
@@ -282,6 +292,7 @@ This program is available under Apache License Version 2.0, available at https:/
           // TODO(jouni): might want to debounce
           this.__boundResizeListener = this._resize.bind(this);
           this.__drawerToggleClickListener = this._drawerToggleClick.bind(this);
+          this.__closeOverlayDrawerListener = this.__closeOverlayDrawer.bind(this);
         }
 
         /**
@@ -316,6 +327,8 @@ This program is available under Apache License Version 2.0, available at https:/
           });
           this._updateDrawerSize();
           this._updateOverlayMode();
+
+          window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
         }
 
         /**
@@ -327,6 +340,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this._navbarChildObserver && this._navbarChildObserver.disconnect();
           window.removeEventListener('resize', this.__boundResizeListener);
           this.removeEventListener('drawer-toggle-click', this.__drawerToggleClickListener);
+          this.removeEventListener('close-overlay-drawer', this.__drawerToggleClickListener);
+        }
+
+        /**
+         * Helper static method that dispatches a `close-overlay-drawer` event
+         */
+        static dispatchCloseOverlayDrawerEvent() {
+          window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
         }
 
         _isShadyCSS() {
@@ -341,6 +362,22 @@ This program is available under Apache License Version 2.0, available at https:/
         _drawerToggleClick(e) {
           e.stopPropagation();
           this.drawerOpened = !this.drawerOpened;
+        }
+
+        /**
+         * App Layout listens to `close-overlay-drawer` on the window level.
+         * A custom event can be dispatched and the App Layout will close the drawer in overlay.
+         *
+         * That can be used, for instance, when a navigation occurs when user clicks in a menu item inside the drawer.
+         *
+         * See `dispatchCloseOverlayDrawerEvent()` helper method.
+         *
+         * @event close-overlay-drawer
+         */
+        __closeOverlayDrawer() {
+          if (this.overlay) {
+            this.drawerOpened = false;
+          }
         }
 
         _updateDrawerSize() {

--- a/test/vaadin-app-layout-test.html
+++ b/test/vaadin-app-layout-test.html
@@ -94,7 +94,7 @@
 
       it('should close drawer when calling helper method', () => {
         // force overlay=true to show backdrop
-        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': true});
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': 'true'});
         layout._updateOverlayMode();
         layout.drawerOpened = true;
 
@@ -106,7 +106,7 @@
 
       it('should close drawer when dispatching custom event', () => {
         // force overlay=true to show backdrop
-        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': true});
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': 'true'});
         layout._updateOverlayMode();
         layout.drawerOpened = true;
 

--- a/test/vaadin-app-layout-test.html
+++ b/test/vaadin-app-layout-test.html
@@ -91,6 +91,24 @@
 
         expect(layout.drawerOpened).to.be.false;
       });
+
+      it('should close drawer when calling helper method', () => {
+        layout.overlay = true;
+        layout.drawerOpened = true;
+
+        Vaadin.AppLayoutElement.dispatchCloseOverlayDrawerEvent();
+
+        expect(layout.drawerOpened).to.be.false;
+      });
+
+      it('should close drawer when dispatching custom event', () => {
+        layout.overlay = true;
+        layout.drawerOpened = true;
+
+        window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
+
+        expect(layout.drawerOpened).to.be.false;
+      });
     });
   </script>
 </body>

--- a/test/vaadin-app-layout-test.html
+++ b/test/vaadin-app-layout-test.html
@@ -93,21 +93,28 @@
       });
 
       it('should close drawer when calling helper method', () => {
-        layout.overlay = true;
+        // force overlay=true to show backdrop
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': true});
+        layout._updateOverlayMode();
         layout.drawerOpened = true;
 
         Vaadin.AppLayoutElement.dispatchCloseOverlayDrawerEvent();
 
         expect(layout.drawerOpened).to.be.false;
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': null});
       });
 
       it('should close drawer when dispatching custom event', () => {
-        layout.overlay = true;
+        // force overlay=true to show backdrop
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': true});
+        layout._updateOverlayMode();
         layout.drawerOpened = true;
 
         window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
 
         expect(layout.drawerOpened).to.be.false;
+        window.ShadyCSS.styleSubtree(layout, {'--vaadin-app-layout-drawer-overlay': null});
+
       });
     });
   </script>


### PR DESCRIPTION
Add a way for the developer to close the drawer in overlay mode
by dispatching a custom event.
Create a helper static method for dispatching the event.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/91)
<!-- Reviewable:end -->
