### PR TITLE
Update vaadin-demo-helpers, remove tabs resolution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,11 +37,8 @@
     "iron-demo-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
-    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.4",
+    "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.0.0",
     "vaadin-tabs": "vaadin/vaadin-tabs#^3.0.0",
     "vaadin-icons": "vaadin/vaadin-icons#^4.2.0"
-  },
-  "resolutions": {
-    "vaadin-tabs": "^3.0.0"
   }
 }

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,9 +1,0 @@
-{
-  "files": ["package.json"],
-  "from": [
-    "\"resolutions\": {"
-  ],
-  "to": [
-    "\"resolutions\": {\n\"@vaadin/vaadin-tabs\": \"3.0.0\","
-  ]
-}


### PR DESCRIPTION
Recently released `vaadin-demo-helpers` is now using `vaadin-tabs` 3.0 so let's update it here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/101)
<!-- Reviewable:end -->
