### PR TITLE
Add z-index to navbar

### DIFF
--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -73,6 +73,7 @@ This program is available under Apache License Version 2.0, available at https:/
         padding-top: var(--safe-area-inset-top);
         padding-left: var(--safe-area-inset-left);
         padding-right: var(--safe-area-inset-right);
+        z-index: 1;
       }
 
       :host([primary-section="drawer"][drawer-opened]:not([overlay])) [part="navbar"] {


### PR DESCRIPTION
On mobile, the content is being presented on top of navbar.

#### Before

![image](https://user-images.githubusercontent.com/262432/59036937-e8851680-8878-11e9-87ab-33e51e484991.png)

#### After

![image](https://user-images.githubusercontent.com/262432/59036990-02265e00-8879-11e9-9170-bf8c7d038d4b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-app-layout/104)
<!-- Reviewable:end -->
