### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,1 @@
+export type PrimarySection = 'navbar' | 'drawer';

--- a/bower.json
+++ b/bower.json
@@ -26,11 +26,11 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.0",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0"
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,16 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "src/detect-ios-navbar.js",
+    "src/safe-area-inset.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "PrimarySection"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-app-layout.js',
+    'vaadin-drawer-toggle.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -316,6 +316,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * Defines whether navbar or drawer will come first visually.
              * - By default (`primary-section="navbar"`), the navbar takes the full available width and moves the drawer down.
              * - If `primary-section="drawer"` is set, then the drawer will move the navbar, taking the full available height.
+             * @type {!PrimarySection}
              */
             primarySection: {
               type: String,
@@ -330,6 +331,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * Its default value depends on the viewport:
              * - `true`, for desktop size views
              * - `false`, for mobile size views
+             * @type {boolean}
              */
             drawerOpened: {
               type: Boolean,
@@ -342,6 +344,7 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              *  Drawer is an overlay on top of the content
              *  Controlled via CSS using `--vaadin-app-layout-drawer-overlay: true|false`;
+             * @type {boolean}
              */
             overlay: {
               type: Boolean,
@@ -361,9 +364,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__closeOverlayDrawerListener = this.__closeOverlayDrawer.bind(this);
         }
 
-        /**
-        * @private
-        */
+        /** @protected */
         connectedCallback() {
           super.connectedCallback();
 
@@ -406,9 +407,7 @@ This program is available under Apache License Version 2.0, available at https:/
           window.addEventListener('close-overlay-drawer', this.__closeOverlayDrawerListener);
         }
 
-        /**
-        * @private
-        */
+        /** @protected */
         disconnectedCallback() {
           super.disconnectedCallback();
 
@@ -427,6 +426,7 @@ This program is available under Apache License Version 2.0, available at https:/
           window.dispatchEvent(new CustomEvent('close-overlay-drawer'));
         }
 
+        /** @private */
         _primarySectionObserver(value) {
           const isValid = ['navbar', 'drawer'].indexOf(value) !== -1;
           if (!isValid) {
@@ -434,6 +434,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _drawerOpenedObserver() {
           const drawer = this.$.drawer;
 
@@ -448,16 +449,18 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
-
+        /** @private */
         _isShadyCSS() {
           return window.ShadyCSS && !window.ShadyCSS.nativeCss;
         }
 
+        /** @protected */
         _afterFirstRender() {
           this._blockAnimationUntilAfterNextRender();
           this._updateOffsetSize();
         }
 
+        /** @private */
         _drawerToggleClick(e) {
           e.stopPropagation();
           this.drawerOpened = !this.drawerOpened;
@@ -479,6 +482,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @protected */
         _updateDrawerSize() {
           const childCount = this.querySelectorAll('[slot=drawer]').length;
           const drawer = this.$.drawer;
@@ -491,12 +495,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this._updateOffsetSize();
         }
 
+        /** @private */
         _resize() {
           this._blockAnimationUntilAfterNextRender();
           this._updateTouchOptimizedMode();
           this._updateOverlayMode();
         }
 
+        /** @protected */
         _updateOffsetSize() {
           const navbar = this.shadowRoot.querySelector('[part="navbar"]');
           const navbarRect = navbar.getBoundingClientRect();
@@ -528,6 +534,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @protected */
         _updateDrawerHeight() {
           const {scrollHeight, offsetHeight} = this.$.drawer;
           const height = scrollHeight > offsetHeight ? `${scrollHeight}px` : '100%';
@@ -541,6 +548,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @protected */
         _updateOverlayMode() {
           const overlay = this._getCustomPropertyValue('--vaadin-app-layout-drawer-overlay') == 'true';
           const drawer = this.$.drawer;
@@ -572,10 +580,12 @@ This program is available under Apache License Version 2.0, available at https:/
           // TODO(jouni): ARIA attributes. The drawer should act similar to a modal dialog when in ”overlay” mode
         }
 
+        /** @protected */
         _close() {
           this.drawerOpened = false;
         }
 
+        /** @private */
         _getCustomPropertyValue(customProperty) {
           let customPropertyValue;
 
@@ -589,6 +599,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return (customPropertyValue || '').trim().toLowerCase();
         }
 
+        /** @protected */
         _updateTouchOptimizedMode() {
           const touchOptimized = this._getCustomPropertyValue('--vaadin-app-layout-touch-optimized') == 'true';
 
@@ -623,6 +634,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._updateOffsetSize();
         }
 
+        /** @protected */
         _blockAnimationUntilAfterNextRender() {
           this.setAttribute('no-anim', '');
           Polymer.RenderStatus.afterNextRender(this, () => {

--- a/src/vaadin-app-layout.html
+++ b/src/vaadin-app-layout.html
@@ -466,16 +466,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.drawerOpened = !this.drawerOpened;
         }
 
-        /**
-         * App Layout listens to `close-overlay-drawer` on the window level.
-         * A custom event can be dispatched and the App Layout will close the drawer in overlay.
-         *
-         * That can be used, for instance, when a navigation occurs when user clicks in a menu item inside the drawer.
-         *
-         * See `dispatchCloseOverlayDrawerEvent()` helper method.
-         *
-         * @event close-overlay-drawer
-         */
+        /** @private */
         __closeOverlayDrawer() {
           if (this.overlay) {
             this.drawerOpened = false;
@@ -644,6 +635,17 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           });
         }
+
+        /**
+         * App Layout listens to `close-overlay-drawer` on the window level.
+         * A custom event can be dispatched and the App Layout will close the drawer in overlay.
+         *
+         * That can be used, for instance, when a navigation occurs when user clicks in a menu item inside the drawer.
+         *
+         * See `dispatchCloseOverlayDrawerEvent()` helper method.
+         *
+         * @event close-overlay-drawer
+         */
       }
 
       customElements.define(AppLayoutElement.is, AppLayoutElement);

--- a/src/vaadin-drawer-toggle.html
+++ b/src/vaadin-drawer-toggle.html
@@ -73,7 +73,6 @@ This program is available under Apache License Version 2.0, available at https:/
        * </vaadin-app-layout>
        * ```
        *
-       * @memberof Vaadin
        * @extends Vaadin.ButtonElement
        * @demo demo/index.html
        */
@@ -95,11 +94,6 @@ This program is available under Apache License Version 2.0, available at https:/
             this.dispatchEvent(new CustomEvent('drawer-toggle-click', {bubbles: true, composed: true}));
           });
         }
-
-        connectedCallback() {
-          super.connectedCallback();
-        }
-
       }
 
       customElements.define(DrawerToggleElement.is, DrawerToggleElement);


### PR DESCRIPTION
Fixes #156 

Generated TS definitions files look like this:

### `vaadin-app-layout.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {beforeNextRender, afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class AppLayoutElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  primarySection: PrimarySection;
  drawerOpened: boolean;
  readonly overlay: boolean;
  static dispatchCloseOverlayDrawerEvent(): void;
  connectedCallback(): void;
  disconnectedCallback(): void;
  _afterFirstRender(): void;
  _updateDrawerSize(): void;
  _updateOffsetSize(): void;
  _updateDrawerHeight(): void;
  _updateOverlayMode(): void;
  _close(): void;
  _updateTouchOptimizedMode(): void;
  _blockAnimationUntilAfterNextRender(): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-app-layout": AppLayoutElement;
  }
}

export {AppLayoutElement};

import {PrimarySection} from '../@types/interfaces';
```

### `vaadin-drawer-toggle.d.ts`

```ts
import {ButtonElement} from '@vaadin/vaadin-button/src/vaadin-button.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class DrawerToggleElement extends ButtonElement {
  ariaLabel: string|null|undefined;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-drawer-toggle": DrawerToggleElement;
  }
}

export {DrawerToggleElement};
```