### PR TITLE
chore: update status badges in README [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,9 @@
 [API documentation ↗](https://vaadin.com/components/vaadin-app-layout/html-api)
 
 [![npm version](https://badgen.net/npm/v/@vaadin/vaadin-app-layout)](https://www.npmjs.com/package/@vaadin/vaadin-app-layout)
-[![Bower version](https://badgen.net/github/release/vaadin/vaadin-app-layout)](https://github.com/vaadin/vaadin-app-layout/releases)
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/vaadin/vaadin-app-layout)
-[![Build Status](https://travis-ci.org/vaadin/vaadin-app-layout.svg?branch=master)](https://travis-ci.org/vaadin/vaadin-app-layout)
-[![Coverage Status](https://coveralls.io/repos/github/vaadin/vaadin-app-layout/badge.svg?branch=master)](https://coveralls.io/github/vaadin/vaadin-app-layout?branch=master)
-[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/vaadin/web-components?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Published on Vaadin  Directory](https://img.shields.io/badge/Vaadin%20Directory-published-00b4f0.svg)](https://vaadin.com/directory/component/vaadinvaadin-app-layout)
-[![Stars on vaadin.com/directory](https://img.shields.io/vaadin-directory/star/vaadin-app-layout-directory-urlidentifier.svg)](https://vaadin.com/directory/component/vaadinvaadin-app-layout)
+[![Published on Vaadin Directory](https://img.shields.io/badge/Vaadin%20Directory-published-00b4f0.svg)](https://vaadin.com/directory/component/vaadinvaadin-app-layout)
+[![Discord](https://discordapp.com/api/guilds/732335336448852018/widget.png)](https://vaad.in/chat)
 
 ```html
 <vaadin-app-layout>


### PR DESCRIPTION
## Description

Some badges are no longer relevant and need removal:

- Bower version: it's always the same as for npm so we can remove it and only show npm version,
- Build status: we have moved away from Travis and do not build on push to master anymore,
- Gitter: we stopped using Gitter and now use Discord (added the corresponding badge),
- Coveralls: related to the above, we no longer upload code coverage to Coveralls service,
- Directory rating: in this case the badge is broken and IMO one Directory badge is enough.

## Type of change

- [x] Internal change